### PR TITLE
Use docker for rpm building/signing to remove the need for a separate…

### DIFF
--- a/rpm-build-docker/Dockerfile
+++ b/rpm-build-docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM debian:bullseye-slim
+WORKDIR /usr/src/sdw
+
+#npm has some prompts on installation. let's suppres them
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies
+RUN apt-get update
+RUN apt-get install -y git gpg
+RUN apt-get --yes install binutils
+RUN apt-get install --no-install-recommends -y \
+            		python3 python3-venv python3-setuptools file python3-rpm \
+            		rpm rpm-common diffoscope reprotest disorderfs faketime xvfb
+

--- a/scripts/build-sign-upload-dom0-rpm.sh
+++ b/scripts/build-sign-upload-dom0-rpm.sh
@@ -3,22 +3,43 @@ set -e
 # This script calls out to the existing build-rpm script then signs the resulting file with the guardian's private key, and uploads it to S3
 
 SCRIPT_PATH=$( cd $(dirname $0) ; pwd -P )
+export AWS_PROFILE=investigations
+export AWS_DEFAULT_REGION=eu-west-1
 
-$SCRIPT_PATH/build-dom0-rpm
+STAGE=${1:-"CODE"}
 
-# Fetch key from secrets manager and import into temporary gpg keyring
-aws secretsmanager get-secret-value --region eu-west-1 --secret-id "$SIGNING_KEY_SECRET_ID" | jq .SecretString -r > /home/admin/private.asc
+if [[ $STAGE != 'CODE' && $STAGE != 'PROD' ]]; then
+  echo "Stage must be CODE or PROD (case sensitive)"
+  exit 1
+fi
 
-KEYRING="gu-securedrop-temporary.gpg" # this must correspond to value set in /home/admin/.rpmmacros
-gpg --no-default-keyring  --keyring $KEYRING  --pinentry loopback --import /home/admin/private.asc
+mkdir -p /tmp/sdw
+
+
+DOCKER_BASE_COMMAND="docker run -v $SCRIPT_PATH/../:/src -v /tmp/sdw:/tmp "
+DOCKER_RUN_COMMAND="sdwbuild /bin/sh -c "
+
+# Build docker container
+docker build -t sdwbuild $SCRIPT_PATH/../rpm-build-docker
+
+# Generate RPM
+$DOCKER_BASE_COMMAND $DOCKER_RUN_COMMAND 'cd /src; scripts/build-dom0-rpm'
+
+# Fetch key from secrets manager
+SIGNING_KEY_SECRET_ID=$(aws ssm get-parameter --name /$STAGE/investigations/securedrop-workstation/signingKeySecretId | jq -r .Parameter.Value)
+aws secretsmanager get-secret-value --region eu-west-1 --secret-id "$SIGNING_KEY_SECRET_ID" | jq .SecretString -r > /tmp/sdw/private.asc
 
 # Sign RPM
-LATEST_RPM_PATH="$(find $SCRIPT_PATH/../rpm-build/ -type f -iname '*.rpm' -print0 | sort -zV | head -n 1 )"
-rpm --addsign "$LATEST_RPM_PATH"
+echo "Signing RPM..."
+$DOCKER_BASE_COMMAND -it $DOCKER_RUN_COMMAND /src/scripts/sign-rpm.sh $STAGE
 
+echo "Uploading signed RPM..."
+LATEST_RPM_PATH=$(find /$SCRIPT_PATH/../rpm-build/ -type f -iname '*.rpm' -print0 | sort -zV | head -n 1 )
 LATEST_RPM_FILENAME="$(basename "$LATEST_RPM_PATH")"
 
 # Upload
-aws s3 cp "$LATEST_RPM_PATH" s3://$WORKSTATION_RELEASE_BUCKET/$LATEST_RPM_FILENAME
+RELEASE_BUCKET=$(aws ssm get-parameter --name /$STAGE/investigations/securedrop-workstation/releaseBucket | jq -r .Parameter.Value)
+aws s3 cp "$LATEST_RPM_PATH" s3://$RELEASE_BUCKET/$LATEST_RPM_FILENAME
 
-rm ~/.gnupg/$KEYRING
+# Tidy up temp files
+rm /tmp/private.asc

--- a/scripts/sign-rpm.sh
+++ b/scripts/sign-rpm.sh
@@ -6,7 +6,7 @@ set -e
 
 STAGE=${1}
 
-KEYRING="gu-securedrop-temporary.gpg" # this must correspond to value set in /home/admin/.rpmmacros
+KEYRING="gu-securedrop-temporary.gpg" # this must correspond to value set in ~/.rpmmacros
 
 gpg --no-default-keyring --keyring $KEYRING  --pinentry loopback --import /tmp/private.asc
 

--- a/scripts/sign-rpm.sh
+++ b/scripts/sign-rpm.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This script is designed to be run inside a debian docker container (see rpm-build-docker/Dockerfile) - it assumes that
+# the guardian/securedrop-workstation repo is mounted at the location /src in the container
+
+set -e
+
+STAGE=${1}
+
+KEYRING="gu-securedrop-temporary.gpg" # this must correspond to value set in /home/admin/.rpmmacros
+
+gpg --no-default-keyring --keyring $KEYRING  --pinentry loopback --import /tmp/private.asc
+
+# Make rpm config file
+cat > /root/.rpmmacros << EOF
+%_gpg_name guardian-securedrop-release-$STAGE <digital.investigations@theguardian.com>
+%__gpg /usr/bin/gpg
+%__gpg_sign_cmd %{__gpg} gpg --force-v3-sigs --verbose --no-armor --pinentry loopback --keyring gu-securedrop-temporary.gpg --no-secmem-warning -u "%{_gpg_name}" -sbo %{__signature_filename} --digest-algo sha256 %{__plaintext_filename}'
+EOF
+
+# Locate rpm file
+LATEST_RPM_PATH=$(find /src/rpm-build/ -type f -iname '*.rpm' -print0 | sort -zV | head -n 1 )
+
+#Sign RPM
+rpm --addsign "$LATEST_RPM_PATH"


### PR DESCRIPTION
This PR modifies the existing build-sign-upload-dom0-rpm script to use a docker container so that it can be run on macos rather than needing to be a linux machine. 

Changes include:
 - Dockerfile with necessary dependencies
 - Fetching the secret key from secrets manager, fetching the secret ID from parameter store (as this repo is in the open I'm trying to minimise 'private' stuff included in the build scripts)
 - A script to handle signing the RPM (this was previously done in the same script but now it needs to be run in a docker container it's easier to have it in a separate file) 