### PR TITLE
 Use new build-rpm script, build on fedora container (attempt 2!)

### DIFF
--- a/rpm-build-docker/Dockerfile
+++ b/rpm-build-docker/Dockerfile
@@ -1,14 +1,14 @@
-FROM debian:bullseye-slim
+FROM fedora:38
 WORKDIR /usr/src/sdw
 
 #npm has some prompts on installation. let's suppres them
 ARG DEBIAN_FRONTEND=noninteractive
 
 # Install build dependencies
-RUN apt-get update
-RUN apt-get install -y git gpg
-RUN apt-get --yes install binutils
-RUN apt-get install --no-install-recommends -y \
-            		python3 python3-venv python3-setuptools file python3-rpm \
-            		rpm rpm-common diffoscope reprotest disorderfs faketime xvfb
-
+RUN dnf -y update
+RUN dnf install -y git gpg
+RUN dnf install -y \
+    python3 python3-setuptools python3-rpm \
+    rpm diffoscope reprotest faketime  \
+    python3-pip python3-wheel python3-devel rpm-sign
+RUN python3 --version

--- a/scripts/build-sign-upload-dom0-rpm.sh
+++ b/scripts/build-sign-upload-dom0-rpm.sh
@@ -23,7 +23,7 @@ DOCKER_RUN_COMMAND="sdwbuild /bin/sh -c "
 docker build -t sdwbuild $SCRIPT_PATH/../rpm-build-docker
 
 # Generate RPM
-$DOCKER_BASE_COMMAND $DOCKER_RUN_COMMAND 'cd /src; scripts/build-dom0-rpm'
+$DOCKER_BASE_COMMAND $DOCKER_RUN_COMMAND 'cd /src; scripts/build-rpm.sh'
 
 # Fetch key from secrets manager
 SIGNING_KEY_SECRET_ID=$(aws ssm get-parameter --name /$STAGE/investigations/securedrop-workstation/signingKeySecretId | jq -r .Parameter.Value)


### PR DESCRIPTION
Implements https://github.com/guardian/securedrop-workstation/pull/9 -this time merging into main!