### PR TITLE
Tidy up following merge of fpf securedrop-workstation 1.0

### DIFF
--- a/rpm-build-docker/Dockerfile
+++ b/rpm-build-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:40
+FROM fedora:38
 WORKDIR /usr/src/sdw
 
 #npm has some prompts on installation. let's suppres them

--- a/rpm-build-docker/Dockerfile
+++ b/rpm-build-docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:40
 WORKDIR /usr/src/sdw
 
 #npm has some prompts on installation. let's suppres them

--- a/securedrop_salt/guardian-securedrop-repo.sls
+++ b/securedrop_salt/guardian-securedrop-repo.sls
@@ -9,7 +9,7 @@ install-apt-transport:
 /etc/apt/s3auth.conf:
   file.managed:
     - name: /etc/apt/s3auth.conf
-    - source: "salt://s3auth.conf.j2"
+    - source: "salt://securedrop_salt/s3auth.conf.j2"
     - template: jinja
     - context:
         access_key_id: {{ d.guardian.aws.access_key_id }}
@@ -20,7 +20,7 @@ install-apt-transport:
 
 add guardian securedrop repo:
   pkgrepo.managed:
-    - name: "deb s3://{{ d.guardian.apt_repo_bucket }}/ bullseye main"
-    - key_url: "salt://sd/sd-workstation/{{ d.guardian.signing_key_filename }}"
+    - name: "deb s3://{{ d.guardian.apt_repo_bucket }}/ bookworm main"
+    - key_url: "salt://securedrop_salt/{{ d.guardian.signing_key_filename }}"
     - humanname: Guardian securedrop PPA
 

--- a/securedrop_salt/guardian-securedrop-repo.sls
+++ b/securedrop_salt/guardian-securedrop-repo.sls
@@ -1,4 +1,4 @@
-{% import_json "sd/config.json" as d %}
+{% import_json "securedrop_salt/config.json" as d %}
 
 install-apt-transport:
   pkg.installed:

--- a/securedrop_salt/sd-app-files.sls
+++ b/securedrop_salt/sd-app-files.sls
@@ -21,3 +21,4 @@ install-securedrop-client-package:
       - securedrop-client
     - require:
       - sls: securedrop_salt.guardian-securedrop-repo
+      - sls: securedrop_salt.sd-logging-setup

--- a/securedrop_salt/sd-app-files.sls
+++ b/securedrop_salt/sd-app-files.sls
@@ -9,6 +9,8 @@
 #
 ##
 include:
+  - securedrop_salt.fpf-apt-repo
+  - securedrop_salt.sd-logging-setup
   - securedrop_salt.guardian-securedrop-repo
 
 # FPF repo is setup in "securedrop-workstation-$sdvars.distribution" template,
@@ -20,5 +22,5 @@ install-securedrop-client-package:
     - pkgs:
       - securedrop-client
     - require:
+      - sls: securedrop_salt.fpf-apt-repo
       - sls: securedrop_salt.guardian-securedrop-repo
-      - sls: securedrop_salt.sd-logging-setup


### PR DESCRIPTION
## Status

Following from https://github.com/guardian/securedrop-workstation/pull/11 this PR contains a few fixes:
 -  files which have moved from salt/sd to salt/securedrop_salt (should have been done in original merge pr)
 - Adding back some lines mistakenly removed from sd-app-files (it's fine to have FPF apt repo as well as ours - because our version numbers are higher we'll always use the guardian version of securedrop-client)

I've tested this on my securedrop dev machine
